### PR TITLE
Improved debug apparatus

### DIFF
--- a/Sources/AnalyticsLive/Signals/Broadcasters/SegmentBroadcaster.swift
+++ b/Sources/AnalyticsLive/Signals/Broadcasters/SegmentBroadcaster.swift
@@ -11,26 +11,32 @@ import Segment
 public class SegmentBroadcaster: SignalBroadcaster {
     public weak var analytics: Analytics? = nil {
         didSet {
-            #if DEBUG
-            guard let analytics else { return }
-            self.mini = MiniAnalytics(analytics: analytics)
-            #endif
+            if sendToSegment {
+                guard let analytics else { return }
+                self.mini = MiniAnalytics(analytics: analytics)
+            }
         }
     }
     
+    internal let sendToSegment: Bool
+    internal let obfuscate: Bool
     internal var mini: MiniAnalytics? = nil
     
     public func added(signal: any RawSignal) {
-        #if DEBUG
-        mini?.track(signal: signal)
-        #endif
+        var s = signal
+        if sendToSegment {
+            mini?.track(signal: s, obfuscate: obfuscate)
+        }
     }
     
     public func relay() {
-        #if DEBUG
-        mini?.flush()
-        #endif
+        if sendToSegment {
+            mini?.flush()
+        }
     }
     
-    public init() { }
+    public init(sendToSegment: Bool = false, obfuscate: Bool = true) {
+        self.obfuscate = obfuscate
+        self.sendToSegment = sendToSegment
+    }
 }

--- a/Sources/AnalyticsLive/Signals/Signals.swift
+++ b/Sources/AnalyticsLive/Signals/Signals.swift
@@ -85,7 +85,6 @@ public class Signals: Plugin, LivePluginsDependent {
     public func useConfiguration(_ configuration: SignalsConfiguration) {
         _configuration.set(configuration)
         
-        addDefaultBroadcasters()
         updateJSConfiguration()
         updateNativeConfiguration()
     
@@ -239,23 +238,12 @@ extension Signals {
         }
     }
     
-    internal func addDefaultBroadcasters() {
-        if let cb = configuration.broadcasters {
-            broadcasters = cb
-        }
-        
-        if !broadcasters.contains(where: { broadcaster in
-            return broadcaster is SegmentBroadcaster
-        }) {
-            broadcasters.append(SegmentBroadcaster())
-        }
-    }
-    
     internal func updateJSConfiguration() {
         signalObject?.setValue(configuration.maximumBufferSize, for: "maxBufferSize")
     }
     
     internal func updateNativeConfiguration() {
+        broadcasters = configuration.broadcasters
         broadcastTimer = QueueTimer(interval: configuration.relayInterval, handler: { [weak self] in
             guard let self else { return }
             for b in self.broadcasters { b.relay() }

--- a/Sources/AnalyticsLive/Signals/Utilities/Obfuscation.swift
+++ b/Sources/AnalyticsLive/Signals/Utilities/Obfuscation.swift
@@ -46,13 +46,6 @@ extension NetworkSignal: JSONObfuscation {
 
 extension JSONObfuscation {
     func obfuscate(_ data: JSON?) -> JSON? {
-        #if DEBUG
-        let debugging = true
-        #else
-        let debugging = false
-        #endif
-        if debugging { return data }
-        
         guard let data else { return data }
         
         switch data {

--- a/Tests/AnalyticsLiveTests/Signals/SignalsTests.swift
+++ b/Tests/AnalyticsLiveTests/Signals/SignalsTests.swift
@@ -1,3 +1,89 @@
 import XCTest
+import Segment
 @testable import AnalyticsLive
 
+final class TestSignals: XCTestCase {
+    
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testSendToSegment() throws {
+        LivePlugins.clearCache()
+        
+        let config = Configuration(writeKey: "signals_test")
+            .flushInterval(999999999)
+            .flushAt(99999999)
+        let analytics = Analytics(configuration: config)
+                                    
+        let signalsConfig = SignalsConfiguration(
+            writeKey: "signals_test",
+            sendDebugSignalsToSegment: true
+        )
+        
+        // set up an observer.
+        let expectation = self.expectation(description: "observer called")
+        MiniAnalytics.observer = { signal, event in
+            print("signal: \(signal.prettyPrint())")
+            print("event: \(event.prettyPrint())")
+            
+            XCTAssertEqual(event.properties.value(forKeyPath: "data.data.customer_name"), "XXXX XXX")
+            XCTAssertEqual(event.properties.value(forKeyPath: "data.data.price"), "99.99")
+            expectation.fulfill()
+        }
+        Signals.shared.useConfiguration(signalsConfig)
+        analytics.add(plugin: LivePlugins(fallbackFileURL: bundleTestFile(file: "MyEdgeFunctions.js")))
+        analytics.add(plugin: Signals.shared)
+        
+        analytics.waitUntilStarted()
+        
+        let localData = LocalDataSignal(action: .loaded, identifier: "1234", data: ["price": "19.95", "customer_name": "John Doe"])
+        Signals.emit(signal: localData)
+        
+        waitForExpectations(timeout: 5) { error in
+            
+        }
+    }
+    
+    func testSendToSegmentUnobfuscated() throws {
+        LivePlugins.clearCache()
+        
+        let config = Configuration(writeKey: "signals_test2")
+            .flushInterval(999999999)
+            .flushAt(99999999)
+        let analytics = Analytics(configuration: config)
+                                    
+        let signalsConfig = SignalsConfiguration(
+            writeKey: "signals_test2",
+            sendDebugSignalsToSegment: true,
+            obfuscateDebugSignals: false
+        )
+        
+        // set up an observer.
+        let expectation = self.expectation(description: "observer called")
+        MiniAnalytics.observer = { signal, event in
+            print("signal: \(signal.prettyPrint())")
+            print("event: \(event.prettyPrint())")
+            
+            XCTAssertEqual(event.properties.value(forKeyPath: "data.data.customer_name"), "John Doe")
+            XCTAssertEqual(event.properties.value(forKeyPath: "data.data.price"), "19.95")
+            expectation.fulfill()
+        }
+        Signals.shared.useConfiguration(signalsConfig)
+        analytics.add(plugin: LivePlugins(fallbackFileURL: bundleTestFile(file: "MyEdgeFunctions.js")))
+        analytics.add(plugin: Signals.shared)
+        
+        analytics.waitUntilStarted()
+        
+        let localData = LocalDataSignal(action: .loaded, identifier: "1234", data: ["price": "19.95", "customer_name": "John Doe"])
+        Signals.emit(signal: localData)
+        
+        waitForExpectations(timeout: 5) { error in
+            
+        }
+    }
+}


### PR DESCRIPTION
- Removed `#if DEBUG` requirement for relaying signals to segment.
- Added sendDebugSignalsToSegment to signals config, defaults to false.
- Added obfuscateDebugSignals to signals config, defaults to true.
- Added tests & internal test infra.

New dev setup to effectively create event generators in the Segment UI would be something like this ...
```swift
let signalsConfig = SignalsConfiguration(
            writeKey: "signals_test2",
#if DEBUG
            sendDebugSignalsToSegment: true, // send signals to segment.
            obfuscateDebugSignals: false // don't obfuscate symbols
#endif
        )
Signals.shared.useConfiguration(signalsConfig)
```