### PR TITLE
ci: migrate GHA to macos-arm + SHA-pinned actions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,63 +2,29 @@ name: Swift
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  cancel_previous:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: styfle/cancel-workflow-action@0.12.0
-        with:
-          workflow_id: ${{ github.event.workflow.id }}
-
-  generate_code_coverage:
-    needs: cancel_previous
-    runs-on: macos-26
-    steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
-      - name: Build & Run tests
-        run: swift test --enable-code-coverage
-      - name: Convert coverage report
-        run: xcrun llvm-cov export -format="lcov" .build/debug/AnalyticsLivePackageTests.xctest/Contents/MacOS/AnalyticsLivePackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: segment-integrations/analytics-swift-live
-
   build_and_test_spm_mac:
-    needs: cancel_previous
-    runs-on: macos-26
+    runs-on: macos-arm
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Build & Run tests
         run: swift test
 
   build_and_test_ios:
-    needs: cancel_previous
-    runs-on: macos-26
+    runs-on: macos-arm
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme AnalyticsLive test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17'
 
   build_and_test_tvos:
-    needs: cancel_previous
-    runs-on: macos-26
+    runs-on: macos-arm
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: xcodebuild -scheme AnalyticsLive test -sdk appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV'


### PR DESCRIPTION
## Summary
- Migrate GitHub Actions CI to Twilio managed runners
- Move all macOS jobs to `macos-arm` (Apple Silicon)
- Remove blocked third-party actions (setup-xcode, cancel-workflow-action, ssh-agent, codecov); use native `concurrency` for cancellation
- Pin GitHub-owned actions to full commit SHA
- Trigger builds on push to any branch
- Refresh stale simulator device names where present

🤖 Generated with [Claude Code](https://claude.com/claude-code)